### PR TITLE
Fix electrode index on units table

### DIFF
--- a/pipeline/export/datajoint_to_nwb.py
+++ b/pipeline/export/datajoint_to_nwb.py
@@ -120,7 +120,7 @@ def export_to_nwb(session_key, nwb_output_dir=default_nwb_output_dir, save=False
         for unit in (ephys.Unit * ephys.UnitCellType & probe_insertion).fetch(as_dict=True):
             # make an electrode table region (which electrode(s) is this unit coming from)
             nwbfile.add_unit(id=unit['unit'],
-                             electrodes=[unit['electrode']-1],
+                             electrodes=[unit['electrode']-1],  # units.electrodes expects 0-indexed array
                              electrode_group=electrode_groups[unit['electrode_group']],
                              sampling_rate=ecephys_fs,
                              quality=unit['unit_quality'],

--- a/pipeline/export/datajoint_to_nwb.py
+++ b/pipeline/export/datajoint_to_nwb.py
@@ -120,7 +120,7 @@ def export_to_nwb(session_key, nwb_output_dir=default_nwb_output_dir, save=False
         for unit in (ephys.Unit * ephys.UnitCellType & probe_insertion).fetch(as_dict=True):
             # make an electrode table region (which electrode(s) is this unit coming from)
             nwbfile.add_unit(id=unit['unit'],
-                             electrodes=[unit['electrode']],
+                             electrodes=[unit['electrode']-1],
                              electrode_group=electrode_groups[unit['electrode_group']],
                              sampling_rate=ecephys_fs,
                              quality=unit['unit_quality'],


### PR DESCRIPTION
The `electrodes` column of the `Units` table expects a list of 0-indexed values corresponding to the rows of the electrodes table. Since `unit[electrode]` is 1-indexed, 1 should be subtracted from that value to get the corresponding 0-indexed row in the electrodes table. 

This could be made more explicit when this convenience function gets released: https://github.com/hdmf-dev/hdmf/pull/187 . You could then use this line: `electrodes=nwbfile.electrodes[ nwbfile.electrodes.id == unit['electrode']],`

This is a critical bug because currently all files have all units that reference the wrong electrode metadata, and several files, such as ANM255201_2014-11-23_4.nwb, cannot be read.